### PR TITLE
Se omite el backbutton event

### DIFF
--- a/src/android/cl/kunder/cordovaNativeLoading/SpinnerPlugin.java
+++ b/src/android/cl/kunder/cordovaNativeLoading/SpinnerPlugin.java
@@ -96,6 +96,21 @@ public class SpinnerPlugin extends CordovaPlugin {
                 layoutPrincipal.addView(linearLayout);
 
                 dialog.setContentView(layoutPrincipal);
+                dialog.setOnCancelListener(new DialogInterface.OnCancelListener() {
+		            @Override
+		            public void onCancel(DialogInterface dialogInterface) {
+
+		            }
+		        });
+		        dialog.setOnKeyListener(new DialogInterface.OnKeyListener() {
+		            @Override
+		            public boolean onKey(DialogInterface dialogInterface, int i, KeyEvent keyEvent) {
+		                if(keyEvent.getKeyCode() == KeyEvent.KEYCODE_BACK)
+		                    return true;
+		                return false;
+		            }
+		        });
+                
                 dialog.show();
 			}
 	  	});


### PR DESCRIPTION
Se ha añadido algunos listeners que capturan el evento del backbutton con el fin de anular la acción sobre el dialogo. Ahora el dialogo no puede ser cerrado por el usuario.
